### PR TITLE
Setup deployment

### DIFF
--- a/.github/workflows/check_build.yaml
+++ b/.github/workflows/check_build.yaml
@@ -14,3 +14,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+
+      - name: Build Docusaurus from source
+        run: yarn build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,9 +4,9 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
   title: 'Truss Engineering Playbook',
-  tagline: '',
-  url: 'https://trussworks.github.io',
-  baseUrl: '/Engineering-Playbook/',
+  tagline: 'Repository of documentation on how we do Software Engineering at TrussWorks.',
+  url: 'https://playbook.truss.dev',
+  baseUrl: '/',
   organizationName: 'trussworks',
   trailingSlash: false,
   onBrokenLinks: 'warn',

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+playbook.truss.dev


### PR DESCRIPTION
This PR sets up some final deployment bits that were missing from the trussworks/Engineering-Playbook#216 PR. 

- I add a `CNAME` for `playbook.truss.dev`
- I add the `yarn build` command for `check_build.yaml`
- I update the Docusaurus configuration to be aware of what the deployed URLs and descriptions are going to be.